### PR TITLE
fix: add `this` bind to onScanSuccess callback

### DIFF
--- a/resources/views/components/qrcode-input.blade.php
+++ b/resources/views/components/qrcode-input.blade.php
@@ -41,6 +41,7 @@
 >
     <div xmlns:x-filament="http://www.w3.org/1999/html"
          x-load-js="['https://unpkg.com/html5-qrcode']"
+         x-on:close-modal.window="stopScanning()"
          x-data="{
         html5QrcodeScanner: null,
         stopScanning() {
@@ -57,17 +58,15 @@
         },
         closeScannerModal() {
             $dispatch('close-modal', { id: 'qrcode-scanner-modal-{{ $getName() }}' });
-            this.stopScanning();
         },
         onScanSuccess(decodedText, decodedResult) {
             $wire.set('{{ $getStatePath() }}', decodedText);
-            $dispatch('close-modal', { id: 'qrcode-scanner-modal-{{ $getName() }}' });
-            this.stopScanning();
+            this.closeScannerModal();
         },
         startCamera() {
             this.html5QrcodeScanner = new Html5QrcodeScanner('reader-{{ $getName() }}', { fps: 10, qrbox: {width: 250, height: 250} }, false);
             this.html5QrcodeScanner.render(this.onScanSuccess.bind(this));
-         }
+        }
      }"
     >
         <div class="grid gap-y-2">

--- a/resources/views/components/qrcode-input.blade.php
+++ b/resources/views/components/qrcode-input.blade.php
@@ -66,7 +66,7 @@
         },
         startCamera() {
             this.html5QrcodeScanner = new Html5QrcodeScanner('reader-{{ $getName() }}', { fps: 10, qrbox: {width: 250, height: 250} }, false);
-            this.html5QrcodeScanner.render(this.onScanSuccess);
+            this.html5QrcodeScanner.render(this.onScanSuccess.bind(this));
          }
      }"
     >


### PR DESCRIPTION
Add a bind of the `this` object to the `onScanSuccess` callback to allow the underlying functions (such as `closeScannerModal`) to execute correctly within the same context.

Fixed issue: Currently, the `closeScannerModal` function does not execute, leaving the scanner running and causing strange behavior.