### PR TITLE
fix: define width and height for icon that triggers the modal for code reading

### DIFF
--- a/resources/views/components/qrcode-input.blade.php
+++ b/resources/views/components/qrcode-input.blade.php
@@ -39,6 +39,12 @@
     :has-inline-label="$hasInlineLabel"
     class="fi-fo-text-input-wrp"
 >
+    <style>
+        .filament-qrcode-field-icon {
+            width: 1.25rem;
+            height: 1.25rem;
+        }
+    </style>
     <div xmlns:x-filament="http://www.w3.org/1999/html"
          x-load-js="['https://unpkg.com/html5-qrcode']"
          x-data="{
@@ -82,10 +88,10 @@
                             aria-label="Scan QrCode">
                         @if($getExtraAttributes()['icon'] ?? null)
                             <span class="text-gray-400 dark:text-gray-200">
-                            <x-dynamic-component :component="$getExtraAttributes()['icon']" class="w-5 h-5"/>
+                            <x-dynamic-component :component="$getExtraAttributes()['icon']" class="filament-qrcode-field-icon" />
                         </span>
                         @else
-                            <svg class="w-5 h-5 text-gray-400 dark:text-gray-200" xmlns="http://www.w3.org/2000/svg"
+                            <svg class="filament-qrcode-field-icon text-gray-400 dark:text-gray-200" xmlns="http://www.w3.org/2000/svg"
                                  version="1.1" viewBox="0 0 16 16"
                                  fill="currentColor">
                                 <path fill="currentColor" d="M6 0h-6v6h6v-6zM5 5h-4v-4h4v4z"></path>


### PR DESCRIPTION
This fix ensures that the QR code scanning icon button has consistent and properly defined dimensions (1.25rem × 1.25rem) across all browsers and UI contexts, providing a more reliable visual presentation for the modal trigger button.

What was changed:
- Added CSS styling - A new <style> block was added to define a CSS class called .filament-qrcode-field-icon that explicitly sets:

> Width: 1.25rem
> Height: 1.25rem

- Updated icon styling references: The hardcoded Tailwind classes (w-5 h-5) were replaced with the new CSS class.

This PR solves the issue #13

@jeffersongoncalves Obrigado por criar esse plugin, um abraço!