### PR TITLE
fix: pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -11,14 +11,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@2.6
+        uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           commit_message: Fix styling

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -11,16 +11,16 @@ jobs:
     name: phpstan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6 # v4
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           # Fetch entire history of repository to ensure release date can be
           # extracted from commit of the given tag.
@@ -32,7 +32,7 @@ jobs:
           echo "date=$(git log -1 --date=short --format=%ad '${{ github.event.release.tag_name }}')" >> $GITHUB_OUTPUT;
 
       - name: Update Changelog
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1
         with:
           # Pass extracted release date, release notes and version to the Action.
           release-date: ${{ steps.release_date.outputs.date }}
@@ -63,7 +63,7 @@ jobs:
         run: "echo ${{ steps.changelog-updater.outputs.unreleased_compare_url }}"
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           # Push updated CHANGELOG to release target branch.
           branch: ${{ github.event.release.target_commitish }}


### PR DESCRIPTION
## Summary
Pins third-party GitHub Actions to full commit SHA instead of tag/branch refs.

## Why
A tag can be re-pointed by a compromised maintainer (tj-actions/changed-files incident, 2025-03) to exfiltrate CI secrets. Pinning to SHA guarantees the code that ran yesterday runs again today.

## Pinned
- actions/checkout@v7 -> 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 (fix-php-code-style-issues.yml)
- aglipanci/laravel-pint-action@2.6 -> 36de00d5f5a8a4e12d443e01671daa12a18f4c79 (fix-php-code-style-issues.yml)
- stefanzweifel/git-auto-commit-action@v7 -> 4a55954c782fc1ea30b9056cd3e7a2b40ca8887d (fix-php-code-style-issues.yml)
- actions/checkout@v7 -> 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 (phpstan.yml)
- shivammathur/setup-php@v2 -> f3e473d116dcccaddc5834248c87452386958240 (phpstan.yml)
- ramsey/composer-install@v4 -> 26d8a556604053a9612623447203a691f406fbe6 (phpstan.yml)
- actions/checkout@v7 -> 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 (update-changelog.yml)
- stefanzweifel/changelog-updater-action@v1 -> a938690fad7edf25368f37e43a1ed1b34303eb36 (update-changelog.yml)
- stefanzweifel/git-auto-commit-action@v7 -> 4a55954c782fc1ea30b9056cd3e7a2b40ca8887d (update-changelog.yml)
